### PR TITLE
add requires attribute for adding additional tracking features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Set your tracking code
 ```html
 <google-analytics-tracker code="UA-12345678-1"></google-analytics-tracker>
 ```
+
+Additional tracking features can be added also
+```html
+<google-analytics-tracker code="UA-12345678-1" requires="displayfeatures"></google-analytics-tracker>
+```

--- a/google-analytics-tracker.html
+++ b/google-analytics-tracker.html
@@ -9,6 +9,12 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', this.getAttribute('code'), 'auto');
+      if(this.hasAttribute('requires')) {
+        var requireArr = this.getAttribute('requires').split(',');
+        for(r in requireArr) {
+          ga('require', r);
+        }        
+      }
       ga('send', 'pageview');
     };
 


### PR DESCRIPTION
uses comma separated values, e.g. requires='displayfeatures,demographics'
